### PR TITLE
42 - Adicionar funcionalidade de visão de satélite

### DIFF
--- a/components/WebGIS/Buttons.tsx
+++ b/components/WebGIS/Buttons.tsx
@@ -12,6 +12,8 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import Button, { ButtonProps } from '@mui/material/Button';
 import MapOutlined from '@mui/icons-material/MapOutlined';
 import MapIcon from '@mui/icons-material/Map';
+import SatelliteAltOutlinedIcon from '@mui/icons-material/SatelliteAltOutlined';
+import SatelliteAltIcon from '@mui/icons-material/SatelliteAlt';
 
 function BaseButton({ children, sx, ...props }: ButtonProps) {
   return (
@@ -67,6 +69,24 @@ export function SettingsButton(props: ButtonProps) {
   return (
     <BaseButton {...props}>
       <SettingsIcon fontSize="medium" />
+    </BaseButton>
+  );
+}
+
+export function SatelliteButton({ active, sx, ...props }: ButtonProps & { active: boolean }) {
+  return (
+    <BaseButton
+      {...props}
+      sx={{
+        background: active ? '#509CBF' : 'gray',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          background: active ? '#509CBF' : 'gray',
+        },
+        ...sx,
+      }}
+    >
+      {active ? <SatelliteAltOutlinedIcon fontSize="medium" /> : <SatelliteAltIcon fontSize="medium" />}
     </BaseButton>
   );
 }

--- a/components/WebGIS/Map/SatelliteLayer.tsx
+++ b/components/WebGIS/Map/SatelliteLayer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+interface SatelliteLayerProps {
+  showSatellite: boolean;
+}
+
+const SatelliteLayer: React.FC<SatelliteLayerProps> = ({ showSatellite }) => {
+  const streetUrl = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const satelliteUrl = 'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+
+  const url = showSatellite ? satelliteUrl : streetUrl ;
+
+  return (
+    <>
+      <TileLayer
+        url={url}
+        attribution='<a href="https://www.mapbox.com/" target="_blank">&copy; Mapbox</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
+        maxZoom={19}
+      />
+    </>
+  );
+};
+
+export default SatelliteLayer;

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,10 +1,11 @@
-import { MapContainer, TileLayer } from 'react-leaflet';
+import React, { useState } from 'react';
+import { MapContainer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-
 import MapController from './MapController';
 import QueimadasGeoJson from './QueimadasLayer';
 import Location from './Location';
 import { LimitsLayer } from './LimitsLayer';
+import SatelliteLayer from './SatelliteLayer'; 
 
 const center = {
   lat: -20.2634,
@@ -14,6 +15,7 @@ const center = {
 interface Props {
   showLocalizacao: boolean;
   showLimitVisibility: boolean;
+  showSatellite: boolean;
   showQueimadas: boolean;
   simplificado: boolean;
   municipio: number;
@@ -24,6 +26,7 @@ interface Props {
 function Map({
   showLocalizacao,
   showLimitVisibility,
+  showSatellite,
   showQueimadas,
   simplificado,
   municipio,
@@ -50,10 +53,7 @@ function Map({
     >
       <MapController ref={forwardRef} />
 
-      <TileLayer
-        url="https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w"
-        attribution='<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
-      />
+      <SatelliteLayer showSatellite = {showSatellite}/>
 
       {showLocalizacao && <Location />}
 

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { MapContainer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import MapController from './MapController';

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -117,7 +117,7 @@ export default function Principal() {
 
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '265px',
+            height: '330px',
           },
 
           '@media (max-width: 600px)': {

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -18,6 +18,7 @@ import {
   MapButton,
   SettingsButton,
   LimitVisibilityButton,
+  SatelliteButton,
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';
 import { SearchMenu } from '../components/WebGIS/SearchMenu';
@@ -33,6 +34,7 @@ export default function Principal() {
   const [showSettings, setShowSettings] = useState(false);
   const [showFire, setShowFire] = useState(true);
   const [showLimitVisibility, setLimitVisibility] = useState(false);
+  const [showSatellite, setSatelliteView] = useState(false);
   const [showLocation, setShowLocation] = useState(false);
   const [simplified, setSimplified] = useState(false);
 
@@ -61,6 +63,7 @@ export default function Principal() {
       <Mapa
         showLocalizacao={showLocation}
         showLimitVisibility={showLimitVisibility}
+        showSatellite={showSatellite}
         showQueimadas={showFire}
         simplificado={simplified}
         municipio={city}
@@ -123,6 +126,11 @@ export default function Principal() {
           },
         }}
       >
+        <SatelliteButton
+          active={showSatellite}
+          onClick={() => setSatelliteView(!showSatellite)}
+        />
+        
         <LimitVisibilityButton
           active={showLimitVisibility}
           onClick={() => setLimitVisibility(!showLimitVisibility)}


### PR DESCRIPTION
Foi adicionada a funcionalidade da visão de satélite do mapa, permitindo ao usuário a possibilidade de visualizar essa camada presente na maioridade de aplicativos de mapa. Foi adicionado um botão para essa funcionalidade logo acima do botão de visibilidade de limite dos municípios, seguindo o padrão de ícones do MUI.