### PR TITLE
49 melhorar localização do boto de visibilidade dos limites de município

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/components/WebGIS/Buttons.tsx
+++ b/components/WebGIS/Buttons.tsx
@@ -10,6 +10,8 @@ import Crop from '@mui/icons-material/CropFree';
 import Map from '@mui/icons-material/FmdGood';
 import SettingsIcon from '@mui/icons-material/Settings';
 import Button, { ButtonProps } from '@mui/material/Button';
+import MapOutlined from '@mui/icons-material/MapOutlined';
+import MapIcon from '@mui/icons-material/Map';
 
 function BaseButton({ children, sx, ...props }: ButtonProps) {
   return (
@@ -65,6 +67,24 @@ export function SettingsButton(props: ButtonProps) {
   return (
     <BaseButton {...props}>
       <SettingsIcon fontSize="medium" />
+    </BaseButton>
+  );
+}
+
+export function LimitVisibilityButton({ active, sx, ...props }: ButtonProps & { active: boolean }) {
+  return (
+    <BaseButton
+      {...props}
+      sx={{
+        background: active ? 'gray' : '#509CBF',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          background: active ? 'gray' : '#509CBF',
+        },
+        ...sx,
+      }}
+    >
+      {active ? <MapOutlined fontSize="medium" /> : <MapIcon fontSize="medium" />}
     </BaseButton>
   );
 }

--- a/components/WebGIS/Buttons.tsx
+++ b/components/WebGIS/Buttons.tsx
@@ -86,7 +86,11 @@ export function SatelliteButton({ active, sx, ...props }: ButtonProps & { active
         ...sx,
       }}
     >
-      {active ? <SatelliteAltOutlinedIcon fontSize="medium" /> : <SatelliteAltIcon fontSize="medium" />}
+      {active ? (
+        <SatelliteAltOutlinedIcon fontSize="medium" />
+      ) : (
+        <SatelliteAltIcon fontSize="medium" />
+      )}
     </BaseButton>
   );
 }

--- a/components/WebGIS/Buttons.tsx
+++ b/components/WebGIS/Buttons.tsx
@@ -12,6 +12,8 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import Button, { ButtonProps } from '@mui/material/Button';
 import MapOutlined from '@mui/icons-material/MapOutlined';
 import MapIcon from '@mui/icons-material/Map';
+import SatelliteAltOutlinedIcon from '@mui/icons-material/SatelliteAltOutlined';
+import SatelliteAltIcon from '@mui/icons-material/SatelliteAlt';
 
 function BaseButton({ children, sx, ...props }: ButtonProps) {
   return (
@@ -67,6 +69,24 @@ export function SettingsButton(props: ButtonProps) {
   return (
     <BaseButton {...props}>
       <SettingsIcon fontSize="medium" />
+    </BaseButton>
+  );
+}
+
+export function SatelliteButton({ active, sx, ...props }: ButtonProps & { active: boolean }) {
+  return (
+    <BaseButton
+      {...props}
+      sx={{
+        background: active ? '#509CBF' : 'gray',
+        '&:hover': {
+          transform: 'translateY(-2px)',
+          background: active ? '#509CBF' : 'gray',
+        },
+        ...sx,
+      }}
+    >
+      {active ? <SatelliteAltOutlinedIcon fontSize="medium" /> : <SatelliteAltIcon fontSize="medium" />}
     </BaseButton>
   );
 }

--- a/components/WebGIS/Map/LimitsLayer.tsx
+++ b/components/WebGIS/Map/LimitsLayer.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import useLimitesMunicipios from '../../../hooks/useLimitesMunicipios';
 import L from 'leaflet';
 
-export function LimitsLayer(props: { municipio: number }) {
+export function LimitsLayer(props: { municipio: number; showLimitVisibility: boolean }) {
   const events = useMapEvents({});
   const { data: limitesMunicipais } = useLimitesMunicipios(props.municipio);
 
@@ -19,8 +19,8 @@ export function LimitsLayer(props: { municipio: number }) {
       pathOptions={{
         dashArray: '0',
         fillColor: '#000000',
-        fillOpacity: 0.1,
-        weight: 2,
+        fillOpacity: props.showLimitVisibility ? 0 : 0.1,
+        weight: props.showLimitVisibility ? 0 : 2,
         opacity: 1,
         color: '#4f4f4f',
       }}
@@ -30,8 +30,8 @@ export function LimitsLayer(props: { municipio: number }) {
           layer.setStyle({
             dashArray: '0',
             fillColor: '#000000',
-            fillOpacity: 0.2,
-            weight: 2,
+            fillOpacity: props.showLimitVisibility ? 0 : 0.1,
+            weight: props.showLimitVisibility ? 0 : 2,
             opacity: 1,
             color: '#3f3f3f',
           });
@@ -39,8 +39,8 @@ export function LimitsLayer(props: { municipio: number }) {
         mouseout: (e) => {
           const layer = e.target;
           layer.setStyle({
-            fillOpacity: 0.1,
-            weight: 2,
+            fillOpacity: props.showLimitVisibility ? 0 : 0.1,
+            weight: props.showLimitVisibility ? 0 : 2,
             dashArray: '0',
             color: '#4f4f4f',
             fillColor: '#000000',

--- a/components/WebGIS/Map/SatelliteLayer.tsx
+++ b/components/WebGIS/Map/SatelliteLayer.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TileLayer } from 'react-leaflet';
+
+interface SatelliteLayerProps {
+  showSatellite: boolean;
+}
+
+const SatelliteLayer: React.FC<SatelliteLayerProps> = ({ showSatellite }) => {
+  const streetUrl = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const satelliteUrl = 'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+
+  const url = showSatellite ? satelliteUrl : streetUrl ;
+
+  return (
+    <>
+      <TileLayer
+        url={url}
+        attribution='<a href="https://www.mapbox.com/" target="_blank">&copy; Mapbox</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
+        maxZoom={19}
+      />
+    </>
+  );
+};
+
+export default SatelliteLayer;

--- a/components/WebGIS/Map/SatelliteLayer.tsx
+++ b/components/WebGIS/Map/SatelliteLayer.tsx
@@ -6,10 +6,12 @@ interface SatelliteLayerProps {
 }
 
 const SatelliteLayer: React.FC<SatelliteLayerProps> = ({ showSatellite }) => {
-  const streetUrl = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
-  const satelliteUrl = 'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const streetUrl =
+    'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const satelliteUrl =
+    'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
 
-  const url = showSatellite ? satelliteUrl : streetUrl ;
+  const url = showSatellite ? satelliteUrl : streetUrl;
 
   return (
     <>

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -1,10 +1,11 @@
-import { MapContainer, TileLayer } from 'react-leaflet';
+import React from 'react';
+import { MapContainer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-
 import MapController from './MapController';
 import QueimadasGeoJson from './QueimadasLayer';
 import Location from './Location';
 import { LimitsLayer } from './LimitsLayer';
+import SatelliteLayer from './SatelliteLayer'; 
 
 const center = {
   lat: -20.2634,
@@ -14,6 +15,7 @@ const center = {
 interface Props {
   showLocalizacao: boolean;
   showLimitVisibility: boolean;
+  showSatellite: boolean;
   showQueimadas: boolean;
   simplificado: boolean;
   municipio: number;
@@ -24,6 +26,7 @@ interface Props {
 function Map({
   showLocalizacao,
   showLimitVisibility,
+  showSatellite,
   showQueimadas,
   simplificado,
   municipio,
@@ -50,10 +53,7 @@ function Map({
     >
       <MapController ref={forwardRef} />
 
-      <TileLayer
-        url="https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/256/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w"
-        attribution='<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
-      />
+      <SatelliteLayer showSatellite = {showSatellite}/>
 
       {showLocalizacao && <Location />}
 

--- a/components/WebGIS/Map/index.tsx
+++ b/components/WebGIS/Map/index.tsx
@@ -13,6 +13,7 @@ const center = {
 
 interface Props {
   showLocalizacao: boolean;
+  showLimitVisibility: boolean;
   showQueimadas: boolean;
   simplificado: boolean;
   municipio: number;
@@ -22,6 +23,7 @@ interface Props {
 
 function Map({
   showLocalizacao,
+  showLimitVisibility,
   showQueimadas,
   simplificado,
   municipio,
@@ -59,7 +61,11 @@ function Map({
         <QueimadasGeoJson municipio={municipio} simplified={simplificado} source={source} />
       )}
 
-      <LimitsLayer municipio={municipio} key={municipio} />
+      <LimitsLayer
+        municipio={municipio}
+        key={municipio}
+        showLimitVisibility={showLimitVisibility}
+      />
     </MapContainer>
   );
 }

--- a/components/WebGIS/MenuModal.tsx
+++ b/components/WebGIS/MenuModal.tsx
@@ -9,10 +9,10 @@ import ItemList from '../ui/ItemList';
 interface Props {
   isDrawerOpen: boolean;
   setIsDrawerOpen: (val: boolean) => void;
-  setIsSettingsVisible: (val: boolean) => void;
+  setShowSettings: (val: boolean) => void;
 }
 
-export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setIsSettingsVisible }: Props) {
+export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setShowSettings }: Props) {
   return (
     <Drawer
       anchor="right"
@@ -78,7 +78,7 @@ export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setIsSettings
       <Grid
         onClick={() => {
           setIsDrawerOpen(false);
-          setIsSettingsVisible(true);
+          setShowSettings(true);
         }}
         sx={{
           position: 'absolute',

--- a/components/WebGIS/SearchMenu/SearchBar.tsx
+++ b/components/WebGIS/SearchMenu/SearchBar.tsx
@@ -31,14 +31,18 @@ const SearchBar: React.FC<{ city: number; source?: string; onChange?: (id?: numb
   const { dataEstados } = useEstados(source);
 
   const data = useMemo(() => {
-    const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) => a.nome.localeCompare(b.nome));
+    const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) =>
+      a.nome.localeCompare(b.nome)
+    );
 
     // Percorrer os estados e suas cidades correspondentes
     return [...(dataEstados || [])]
       ?.sort((a, b) => a.nome.localeCompare(b.nome))
       ?.reduce(
         (memo, estado) =>
-          memo.concat([estado]).concat(sortedMunicipios.filter((municipio) => estado.sigla === municipio.sigla) || []),
+          memo
+            .concat([estado])
+            .concat(sortedMunicipios.filter((municipio) => estado.sigla === municipio.sigla) || []),
         [] as Localizacao[]
       );
   }, [dataMunicipios, dataEstados]);
@@ -66,6 +70,7 @@ const SearchBar: React.FC<{ city: number; source?: string; onChange?: (id?: numb
         handleOnChange(selectedOption);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query]);
 
   return data ? (

--- a/components/WebGIS/SearchMenu/SearchBar.tsx
+++ b/components/WebGIS/SearchMenu/SearchBar.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState, useEffect } from 'react';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import { styled } from '@mui/system';
 import { Popper, Paper } from '@mui/material';
+import { useRouter } from 'next/router';
 import useMunicipios from '../../../hooks/useMunicipios';
 import useEstados from '../../../hooks/useEstados';
 
@@ -27,6 +28,7 @@ export default function SearchBar(props: {
 }) {
   const { dataMunicipios } = useMunicipios(props.source);
   const { dataEstados } = useEstados(props.source);
+  const router = useRouter(); 
 
   const data = useMemo(() => {
     const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) =>
@@ -47,8 +49,14 @@ export default function SearchBar(props: {
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
-
   const [highlightedOption, setHighlightedOption] = useState<number | null>(null);
+  const [selectedMunicipio, setSelectedMunicipio] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (selectedMunicipio) {
+      router.push(`/webgis/${selectedMunicipio}`);
+    }
+  }, [selectedMunicipio]);
 
   return data ? (
     <>
@@ -106,6 +114,7 @@ export default function SearchBar(props: {
         PopperComponent={Popper}
         PaperComponent={CustomPaper}
         onInputChange={(_, value) => {
+          setSelectedMunicipio(value); 
           if (props.onChange) props.onChange(data.find((option) => value == option.nome)?.id);
         }}
         renderInput={(params) => (

--- a/components/WebGIS/SearchMenu/SearchBar.tsx
+++ b/components/WebGIS/SearchMenu/SearchBar.tsx
@@ -6,6 +6,7 @@ import { Popper, Paper } from '@mui/material';
 import { useRouter } from 'next/router';
 import useMunicipios from '../../../hooks/useMunicipios';
 import useEstados from '../../../hooks/useEstados';
+import { useRouter } from 'next/router';
 
 const CustomPaper = styled(Paper)({
   backgroundColor: '#509CBF',
@@ -21,6 +22,7 @@ type Localizacao = {
   queimadas: boolean;
 };
 
+
 export default function SearchBar(props: {
   city: number;
   source?: string;
@@ -30,19 +32,16 @@ export default function SearchBar(props: {
   const { dataEstados } = useEstados(props.source);
   const router = useRouter(); 
 
+
   const data = useMemo(() => {
-    const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) =>
-      a.nome.localeCompare(b.nome)
-    );
+    const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) => a.nome.localeCompare(b.nome));
 
     // Percorrer os estados e suas cidades correspondentes
     return [...(dataEstados || [])]
       ?.sort((a, b) => a.nome.localeCompare(b.nome))
       ?.reduce(
         (memo, estado) =>
-          memo
-            .concat([estado])
-            .concat(sortedMunicipios.filter((municipio) => estado.sigla === municipio.sigla) || []),
+          memo.concat([estado]).concat(sortedMunicipios.filter((municipio) => estado.sigla === municipio.sigla) || []),
         [] as Localizacao[]
       );
   }, [dataMunicipios, dataEstados]);
@@ -57,6 +56,27 @@ export default function SearchBar(props: {
       router.push(`/webgis/${selectedMunicipio}`);
     }
   }, [selectedMunicipio]);
+
+  const handleOnChange = (selectedOption: Localizacao | null) => {
+    if (selectedOption && onChange) {
+      onChange(selectedOption.id);
+      router.push(`/webgis?municipio=${selectedOption.nome}`);
+    } else {
+      router.push(`/webgis`);
+    }
+  };
+
+  useEffect(() => {
+    const { query } = router;
+    const selectedCity = query.municipio;
+    const selectedCityId = data?.find((option) => option.nome === selectedCity)?.id;
+    if (selectedCityId && selectedCityId !== city) {
+      const selectedOption = data.find((option) => option.id === selectedCityId);
+      if (selectedOption) {
+        handleOnChange(selectedOption);
+      }
+    }
+  }, [router.query]);
 
   return data ? (
     <>
@@ -84,14 +104,8 @@ export default function SearchBar(props: {
         getOptionDisabled={(option) => !option.queimadas}
         getOptionLabel={(option) => option.nome}
         noOptionsText="Não existem dados para essa localidade"
-        value={data.find((option) => props.city == option.id)}
-        onChange={() =>
-          setTimeout(() => {
-            if (inputRef.current) {
-              inputRef.current.blur();
-            }
-          }, 0)
-        }
+        value={data.find((option) => city == option.id)}
+        onChange={(_, selectedOption) => handleOnChange(selectedOption)}
         onFocus={() => setIsInputFocused(true)}
         onBlur={() => setIsInputFocused(false)}
         sx={{
@@ -113,10 +127,12 @@ export default function SearchBar(props: {
         }}
         PopperComponent={Popper}
         PaperComponent={CustomPaper}
+
         onInputChange={(_, value) => {
           setSelectedMunicipio(value); 
           if (props.onChange) props.onChange(data.find((option) => value == option.nome)?.id);
         }}
+
         renderInput={(params) => (
           <TextField
             {...params}
@@ -148,4 +164,6 @@ export default function SearchBar(props: {
   ) : (
     <></>
   );
-}
+};
+
+export default SearchBar;

--- a/components/WebGIS/SearchMenu/SearchBar.tsx
+++ b/components/WebGIS/SearchMenu/SearchBar.tsx
@@ -1,9 +1,8 @@
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import TextField from '@mui/material/TextField';
 import Autocomplete from '@mui/material/Autocomplete';
 import { styled } from '@mui/system';
 import { Popper, Paper } from '@mui/material';
-import { useRouter } from 'next/router';
 import useMunicipios from '../../../hooks/useMunicipios';
 import useEstados from '../../../hooks/useEstados';
 import { useRouter } from 'next/router';
@@ -22,16 +21,14 @@ type Localizacao = {
   queimadas: boolean;
 };
 
-
-export default function SearchBar(props: {
-  city: number;
-  source?: string;
-  onChange?: (id?: number) => void;
-}) {
-  const { dataMunicipios } = useMunicipios(props.source);
-  const { dataEstados } = useEstados(props.source);
-  const router = useRouter(); 
-
+const SearchBar: React.FC<{ city: number; source?: string; onChange?: (id?: number) => void }> = ({
+  city,
+  source,
+  onChange,
+}) => {
+  const router = useRouter();
+  const { dataMunicipios } = useMunicipios(source);
+  const { dataEstados } = useEstados(source);
 
   const data = useMemo(() => {
     const sortedMunicipios = [...(dataMunicipios || [])].sort((a, b) => a.nome.localeCompare(b.nome));
@@ -49,13 +46,6 @@ export default function SearchBar(props: {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [highlightedOption, setHighlightedOption] = useState<number | null>(null);
-  const [selectedMunicipio, setSelectedMunicipio] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (selectedMunicipio) {
-      router.push(`/webgis/${selectedMunicipio}`);
-    }
-  }, [selectedMunicipio]);
 
   const handleOnChange = (selectedOption: Localizacao | null) => {
     if (selectedOption && onChange) {
@@ -127,12 +117,6 @@ export default function SearchBar(props: {
         }}
         PopperComponent={Popper}
         PaperComponent={CustomPaper}
-
-        onInputChange={(_, value) => {
-          setSelectedMunicipio(value); 
-          if (props.onChange) props.onChange(data.find((option) => value == option.nome)?.id);
-        }}
-
         renderInput={(params) => (
           <TextField
             {...params}

--- a/components/WebGIS/Settings.tsx
+++ b/components/WebGIS/Settings.tsx
@@ -1,37 +1,33 @@
-import { useState } from 'react';
+import * as React from 'react';
+import { Switch, FormControlLabel } from '@mui/material';
 import Modal from '@mui/material/Modal';
 import { Grid } from '@mui/material';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormControl from '@mui/material/FormControl';
 
 interface Props {
-  isSettingsVisible: boolean;
-  setIsSettingsVisible: (val: boolean) => void;
-  setIsSimplifiedDatas: (val: boolean) => void;
+  showSettings: boolean;
+  setShowSettings: (val: boolean) => void;
+  showSimplifiedData: boolean;
+  setShowSimplifiedData: (simplified: boolean) => void;
+  showLimitVisibility: boolean;
+  setShowLimitVisibility: (val: boolean) => void;
 }
 
 export default function Settings({
-  isSettingsVisible,
-  setIsSettingsVisible,
-  setIsSimplifiedDatas,
+  showSettings,
+  setShowSettings,
+  showSimplifiedData,
+  setShowSimplifiedData,
+  showLimitVisibility,
+  setShowLimitVisibility,
 }: Props) {
-  const [value, setValue] = useState('Sem Simplificação');
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if ((event.target as HTMLInputElement).value == 'Com Simplificação') {
-      setIsSimplifiedDatas(true);
-    } else {
-      setIsSimplifiedDatas(false);
-    }
-    setValue((event.target as HTMLInputElement).value);
-  };
-
+  const createChangeHandler = //Funcao de fabrica para manipular varios switchs sem ter q repetir lógica(isso é provisorio tendo em vista que configuracoes virara um menu lateral)
+    (setter: (value: boolean) => void) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      setter(event.target.checked);
+    };
   return (
     <Modal
-      open={isSettingsVisible}
-      onClose={() => setIsSettingsVisible(false)}
+      open={showSettings}
+      onClose={() => setShowSettings(false)}
       sx={{
         display: 'flex',
         alignItems: 'flex-start',
@@ -82,33 +78,24 @@ export default function Settings({
             marginTop: '10px',
           }}
         >
-          <FormControl>
-            <p style={{ fontSize: '0.8rem', color: 'white' }}>Exibir dados de qual forma?</p>
-            <RadioGroup
-              aria-labelledby="demo-controlled-radio-buttons-group"
-              name="controlled-radio-buttons-group"
-              value={value}
-              onChange={handleChange}
-              sx={{
-                color: 'white',
-                marginTop: '5px',
-                '& .MuiSvgIcon-root': {
-                  color: 'white!important',
-                },
-              }}
-            >
-              <FormControlLabel
-                value="Sem Simplificação"
-                control={<Radio />}
-                label={<span style={{ fontSize: '0.8rem' }}>Sem Simplificação</span>}
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showSimplifiedData}
+                onChange={createChangeHandler(setShowSimplifiedData)}
               />
-              <FormControlLabel
-                value="Com Simplificação"
-                control={<Radio />}
-                label={<span style={{ fontSize: '0.8rem' }}>Com Simplificação</span>}
+            }
+            label={showSimplifiedData ? 'Com Simplificação' : 'Sem Simplificação'}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showLimitVisibility}
+                onChange={createChangeHandler(setShowLimitVisibility)}
               />
-            </RadioGroup>
-          </FormControl>
+            }
+            label={showLimitVisibility ? 'Sem Limites' : 'Com Limites'}
+          />
         </Grid>
       </Grid>
     </Modal>

--- a/components/WebGIS/Settings.tsx
+++ b/components/WebGIS/Settings.tsx
@@ -34,30 +34,33 @@ export default function Settings({
       onClose={() => setIsSettingsVisible(false)}
       sx={{
         display: 'flex',
-        alignItems: 'flex-start', 
+        alignItems: 'flex-start',
         justifyContent: 'flex-end',
-        marginRight:'70px', 
-        marginTop: '18px'
+        marginRight: '70px',
+        marginTop: '18px',
       }}
       slotProps={{
         backdrop: {
           sx: {
-            bgcolor: 'rgba(0, 0, 0, 0)', 
+            bgcolor: 'rgba(0, 0, 0, 0)',
           },
         },
       }}
     >
       <Grid
         sx={{
-            backgroundColor: '#509CBF',
-            left: 'auto!important',
-            right: 'calc(85px + 1rem)',
-            color: 'white',
-            minWidth: '200px!important',
-            minHeight: '180px',
-            '@media (max-width: 1500px)': {
-              right: 'calc(55px + 1rem)',
-            },
+          backgroundColor: '#509CBF',
+          borderRadius: '10px',
+          left: 'auto!important',
+          right: 'calc(85px + 1rem)',
+          color: 'white',
+          minWidth: '200px!important',
+          minHeight: '180px',
+          boxShadow:
+            '0px 5px 5px -3px rgba(0,0,0,0.2), 0px 8px 10px 1px rgba(0,0,0,0.14), 0px 3px 14px 2px rgba(0,0,0,0.12)',
+          '@media (max-width: 1500px)': {
+            right: 'calc(55px + 1rem)',
+          },
         }}
       >
         <h4
@@ -66,7 +69,7 @@ export default function Settings({
             fontSize: '1.3rem',
             fontWeight: '500',
             marginTop: '15px',
-            color: 'white'
+            color: 'white',
           }}
         >
           Configurações
@@ -80,7 +83,7 @@ export default function Settings({
           }}
         >
           <FormControl>
-            <p style={{ fontSize: '0.8rem', color:'white' }}>Exibir dados de qual forma?</p>
+            <p style={{ fontSize: '0.8rem', color: 'white' }}>Exibir dados de qual forma?</p>
             <RadioGroup
               aria-labelledby="demo-controlled-radio-buttons-group"
               name="controlled-radio-buttons-group"

--- a/components/WebGIS/Settings.tsx
+++ b/components/WebGIS/Settings.tsx
@@ -34,45 +34,53 @@ export default function Settings({
       onClose={() => setIsSettingsVisible(false)}
       sx={{
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
+        alignItems: 'flex-start', 
+        justifyContent: 'flex-end',
+        marginRight:'70px', 
+        marginTop: '18px'
+      }}
+      slotProps={{
+        backdrop: {
+          sx: {
+            bgcolor: 'rgba(0, 0, 0, 0)', 
+          },
+        },
       }}
     >
       <Grid
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          height: '275px',
-          width: '550px',
-          backgroundColor: '#509CBF',
-          borderRadius: '15px',
-          color: 'white',
-          '@media (max-width: 1500px)': {
-            height: '250px',
-            width: '450px',
-          },
+            backgroundColor: '#509CBF',
+            left: 'auto!important',
+            right: 'calc(85px + 1rem)',
+            color: 'white',
+            minWidth: '200px!important',
+            minHeight: '180px',
+            '@media (max-width: 1500px)': {
+              right: 'calc(55px + 1rem)',
+            },
         }}
       >
-        <h1
+        <h4
           style={{
             textAlign: 'center',
             fontSize: '1.3rem',
             fontWeight: '500',
             marginTop: '15px',
+            color: 'white'
           }}
         >
           Configurações
-        </h1>
+        </h4>
         <Grid
           sx={{
+            height: 'min-content',
             marginLeft: '20px',
-            display: 'flex',
-            flexDirection: 'column',
-            marginTop: '30px',
+            width: '200px',
+            marginTop: '10px',
           }}
         >
           <FormControl>
-            <p style={{ fontSize: '1.1rem' }}>Exibir dados de qual forma?</p>
+            <p style={{ fontSize: '0.8rem', color:'white' }}>Exibir dados de qual forma?</p>
             <RadioGroup
               aria-labelledby="demo-controlled-radio-buttons-group"
               name="controlled-radio-buttons-group"
@@ -89,12 +97,12 @@ export default function Settings({
               <FormControlLabel
                 value="Sem Simplificação"
                 control={<Radio />}
-                label={<span style={{ fontSize: '1rem' }}>Sem Simplificação</span>}
+                label={<span style={{ fontSize: '0.8rem' }}>Sem Simplificação</span>}
               />
               <FormControlLabel
                 value="Com Simplificação"
                 control={<Radio />}
-                label={<span style={{ fontSize: '1rem' }}>Com Simplificação</span>}
+                label={<span style={{ fontSize: '0.8rem' }}>Com Simplificação</span>}
               />
             </RadioGroup>
           </FormControl>

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -18,6 +18,7 @@ import {
   MapButton,
   SettingsButton,
   LimitVisibilityButton,
+  SatelliteButton,
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';
 import { SearchMenu } from '../components/WebGIS/SearchMenu';
@@ -33,6 +34,7 @@ export default function Principal() {
   const [showSettings, setShowSettings] = useState(false);
   const [showFire, setShowFire] = useState(true);
   const [showLimitVisibility, setLimitVisibility] = useState(false);
+  const [showSatellite, setSatelliteView] = useState(false);
   const [showLocation, setShowLocation] = useState(false);
   const [simplified, setSimplified] = useState(false);
 
@@ -61,6 +63,7 @@ export default function Principal() {
       <Mapa
         showLocalizacao={showLocation}
         showLimitVisibility={showLimitVisibility}
+        showSatellite={showSatellite}
         showQueimadas={showFire}
         simplificado={simplified}
         municipio={city}
@@ -114,7 +117,7 @@ export default function Principal() {
 
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '265px',
+            height: '330px',
           },
 
           '@media (max-width: 600px)': {
@@ -123,6 +126,11 @@ export default function Principal() {
           },
         }}
       >
+        <SatelliteButton
+          active={showSatellite}
+          onClick={() => setSatelliteView(!showSatellite)}
+        />
+        
         <LimitVisibilityButton
           active={showLimitVisibility}
           onClick={() => setLimitVisibility(!showLimitVisibility)}

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -29,11 +29,10 @@ export default function Principal() {
 
   const [city, setCity] = useState(5003207);
   const [source, setSource] = useState<string | undefined>();
-
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFire, setShowFire] = useState(true);
-  const [showLimitVisibility, setLimitVisibility] = useState(false);
+  const [showLimitVisibility, setShowLimitVisibility] = useState(false);
   const [showSatellite, setSatelliteView] = useState(false);
   const [showLocation, setShowLocation] = useState(false);
   const [simplified, setSimplified] = useState(false);
@@ -77,7 +76,7 @@ export default function Principal() {
         sx={{
           position: 'absolute',
           width: '50px',
-          height: '115px',
+          height: '100px',
           top: 0,
           right: 0,
           margin: '1rem',
@@ -86,7 +85,7 @@ export default function Principal() {
           justifyContent: 'space-between',
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '102.5px',
+            height: '110x',
           },
           '@media (max-width: 600px)': {
             top: 'calc(3rem + 40px)',
@@ -106,7 +105,7 @@ export default function Principal() {
         sx={{
           position: 'absolute',
           width: '50px',
-          height: '240px',
+          height: '220px',
           top: '50%',
           right: 0,
           margin: '1rem',
@@ -117,7 +116,7 @@ export default function Principal() {
 
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '330px',
+            height: '220px',
           },
 
           '@media (max-width: 600px)': {
@@ -126,16 +125,6 @@ export default function Principal() {
           },
         }}
       >
-        <SatelliteButton
-          active={showSatellite}
-          onClick={() => setSatelliteView(!showSatellite)}
-        />
-        
-        <LimitVisibilityButton
-          active={showLimitVisibility}
-          onClick={() => setLimitVisibility(!showLimitVisibility)}
-        />
-
         <FireButton active={showFire} onClick={() => setShowFire(!showFire)} />
 
         <ForestButton active={false} disabled />
@@ -147,7 +136,7 @@ export default function Principal() {
       <Grid
         sx={{
           position: 'absolute',
-          width: '240px',
+          width: '340px',
           height: '50px',
           bottom: 0,
           right: 0,
@@ -157,10 +146,12 @@ export default function Principal() {
           justifyContent: 'space-between',
           '@media (max-width: 1500px)': {
             height: '45px',
-            width: '215px',
+            width: '280px',
           },
         }}
       >
+        <SatelliteButton active={showSatellite} onClick={() => setSatelliteView(!showSatellite)} />
+
         <AddButton onClick={() => ref.current?.zoomIn()} />
 
         <RemoveButton onClick={() => ref.current?.zoomOut()} />
@@ -187,13 +178,16 @@ export default function Principal() {
       <MenuModal
         isDrawerOpen={isDrawerOpen}
         setIsDrawerOpen={setIsDrawerOpen}
-        setIsSettingsVisible={setShowSettings}
+        setShowSettings={setShowSettings}
       />
 
       <Settings
-        isSettingsVisible={showSettings}
-        setIsSettingsVisible={setShowSettings}
-        setIsSimplifiedDatas={setSimplified}
+        showSettings={showSettings}
+        setShowSettings={setShowSettings}
+        showSimplifiedData={simplified}
+        setShowSimplifiedData={setSimplified}
+        showLimitVisibility={showLimitVisibility}
+        setShowLimitVisibility={setShowLimitVisibility}
       />
     </>
   );

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -21,7 +21,6 @@ import {
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';
 import { SearchMenu } from '../components/WebGIS/SearchMenu';
-import { LimitsLayer } from '../components/WebGIS/Map/LimitsLayer';
 
 export default function Principal() {
   const [anchorElementOfDownloadButton, setAnchorElementOfDownloadButton] =

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -17,7 +17,6 @@ import {
   CropButton,
   MapButton,
   SettingsButton,
-  LimitVisibilityButton,
   SatelliteButton,
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -17,9 +17,11 @@ import {
   CropButton,
   MapButton,
   SettingsButton,
+  LimitVisibilityButton,
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';
 import { SearchMenu } from '../components/WebGIS/SearchMenu';
+import { LimitsLayer } from '../components/WebGIS/Map/LimitsLayer';
 
 export default function Principal() {
   const [anchorElementOfDownloadButton, setAnchorElementOfDownloadButton] =
@@ -31,6 +33,7 @@ export default function Principal() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFire, setShowFire] = useState(true);
+  const [showLimitVisibility, setLimitVisibility] = useState(false);
   const [showLocation, setShowLocation] = useState(false);
   const [simplified, setSimplified] = useState(false);
 
@@ -58,6 +61,7 @@ export default function Principal() {
 
       <Mapa
         showLocalizacao={showLocation}
+        showLimitVisibility={showLimitVisibility}
         showQueimadas={showFire}
         simplificado={simplified}
         municipio={city}
@@ -108,20 +112,29 @@ export default function Principal() {
           flexDirection: 'column',
           justifyContent: 'space-between',
           transform: 'translateY(-50%)',
+
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '215px',
+            height: '265px',
           },
+
           '@media (max-width: 600px)': {
             transform: 'none',
             marginTop: 0,
           },
         }}
       >
+        <LimitVisibilityButton
+          active={showLimitVisibility}
+          onClick={() => setLimitVisibility(!showLimitVisibility)}
+        />
+
         <FireButton active={showFire} onClick={() => setShowFire(!showFire)} />
 
         <ForestButton active={false} disabled />
+
         <RoadButton active={false} disabled />
+
         <WaterButton active={false} disabled />
       </Grid>
       <Grid


### PR DESCRIPTION
Após a discussão de alguns pontos de melhorias na reunião do dia 03/05/2024, foi realizado a melhoria na disposição de alguns botões relacionados à algumas funcionalidades recentemente implementadas.
Foi decidido que a parte lateral direita do site, ficaria responsável apenas por botões relacionados a visualização de pontos no mapa(queimadas,alagamentos, etc.), portanto, a funcionalidade de visualizar limites de municípios passou para dentro do menu de configurações, esse também que foi mudado para uma lógica de switchs ao invés de radioButton, e o botão que alterna as camadas do mapa, provisoriamente, foi mudado para a parte inferior do mapa, junto com os botões de navegabilidade.
Essa PR resolve os problemas das issues #49 e a #50 