### PR TITLE
49 melhorar localizao do boto de visibilidade dos limites de municpio

### DIFF
--- a/components/WebGIS/Buttons.tsx
+++ b/components/WebGIS/Buttons.tsx
@@ -86,7 +86,11 @@ export function SatelliteButton({ active, sx, ...props }: ButtonProps & { active
         ...sx,
       }}
     >
-      {active ? <SatelliteAltOutlinedIcon fontSize="medium" /> : <SatelliteAltIcon fontSize="medium" />}
+      {active ? (
+        <SatelliteAltOutlinedIcon fontSize="medium" />
+      ) : (
+        <SatelliteAltIcon fontSize="medium" />
+      )}
     </BaseButton>
   );
 }

--- a/components/WebGIS/Map/SatelliteLayer.tsx
+++ b/components/WebGIS/Map/SatelliteLayer.tsx
@@ -6,10 +6,12 @@ interface SatelliteLayerProps {
 }
 
 const SatelliteLayer: React.FC<SatelliteLayerProps> = ({ showSatellite }) => {
-  const streetUrl = 'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
-  const satelliteUrl = 'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const streetUrl =
+    'https://api.mapbox.com/styles/v1/mapbox/streets-v11/tiles/{z}/{x}/{y}@2x?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
+  const satelliteUrl =
+    'https://api.mapbox.com/styles/v1/mapbox/satellite-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWF0aGV1cy1uYW50ZXMiLCJhIjoiY2xhMXpoeTRrMDBvYTNvbWZvZXpua2htOCJ9.PeFH8oujEq1AI6a8-tkk7w';
 
-  const url = showSatellite ? satelliteUrl : streetUrl ;
+  const url = showSatellite ? satelliteUrl : streetUrl;
 
   return (
     <>

--- a/components/WebGIS/MenuModal.tsx
+++ b/components/WebGIS/MenuModal.tsx
@@ -9,10 +9,10 @@ import ItemList from '../ui/ItemList';
 interface Props {
   isDrawerOpen: boolean;
   setIsDrawerOpen: (val: boolean) => void;
-  setIsSettingsVisible: (val: boolean) => void;
+  setShowSettings: (val: boolean) => void;
 }
 
-export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setIsSettingsVisible }: Props) {
+export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setShowSettings }: Props) {
   return (
     <Drawer
       anchor="right"
@@ -78,7 +78,7 @@ export default function MenuModal({ isDrawerOpen, setIsDrawerOpen, setIsSettings
       <Grid
         onClick={() => {
           setIsDrawerOpen(false);
-          setIsSettingsVisible(true);
+          setShowSettings(true);
         }}
         sx={{
           position: 'absolute',

--- a/components/WebGIS/Settings.tsx
+++ b/components/WebGIS/Settings.tsx
@@ -1,37 +1,33 @@
-import { useState } from 'react';
+import * as React from 'react';
+import { Switch, FormControlLabel } from '@mui/material';
 import Modal from '@mui/material/Modal';
 import { Grid } from '@mui/material';
-import Radio from '@mui/material/Radio';
-import RadioGroup from '@mui/material/RadioGroup';
-import FormControlLabel from '@mui/material/FormControlLabel';
-import FormControl from '@mui/material/FormControl';
 
 interface Props {
-  isSettingsVisible: boolean;
-  setIsSettingsVisible: (val: boolean) => void;
-  setIsSimplifiedDatas: (val: boolean) => void;
+  showSettings: boolean;
+  setShowSettings: (val: boolean) => void;
+  showSimplifiedData: boolean;
+  setShowSimplifiedData: (simplified: boolean) => void;
+  showLimitVisibility: boolean;
+  setShowLimitVisibility: (val: boolean) => void;
 }
 
 export default function Settings({
-  isSettingsVisible,
-  setIsSettingsVisible,
-  setIsSimplifiedDatas,
+  showSettings,
+  setShowSettings,
+  showSimplifiedData,
+  setShowSimplifiedData,
+  showLimitVisibility,
+  setShowLimitVisibility,
 }: Props) {
-  const [value, setValue] = useState('Sem Simplificação');
-
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if ((event.target as HTMLInputElement).value == 'Com Simplificação') {
-      setIsSimplifiedDatas(true);
-    } else {
-      setIsSimplifiedDatas(false);
-    }
-    setValue((event.target as HTMLInputElement).value);
-  };
-
+  const createChangeHandler = //Funcao de fabrica para manipular varios switchs sem ter q repetir lógica(isso é provisorio tendo em vista que configuracoes virara um menu lateral)
+    (setter: (value: boolean) => void) => (event: React.ChangeEvent<HTMLInputElement>) => {
+      setter(event.target.checked);
+    };
   return (
     <Modal
-      open={isSettingsVisible}
-      onClose={() => setIsSettingsVisible(false)}
+      open={showSettings}
+      onClose={() => setShowSettings(false)}
       sx={{
         display: 'flex',
         alignItems: 'flex-start',
@@ -82,33 +78,24 @@ export default function Settings({
             marginTop: '10px',
           }}
         >
-          <FormControl>
-            <p style={{ fontSize: '0.8rem', color: 'white' }}>Exibir dados de qual forma?</p>
-            <RadioGroup
-              aria-labelledby="demo-controlled-radio-buttons-group"
-              name="controlled-radio-buttons-group"
-              value={value}
-              onChange={handleChange}
-              sx={{
-                color: 'white',
-                marginTop: '5px',
-                '& .MuiSvgIcon-root': {
-                  color: 'white!important',
-                },
-              }}
-            >
-              <FormControlLabel
-                value="Sem Simplificação"
-                control={<Radio />}
-                label={<span style={{ fontSize: '0.8rem' }}>Sem Simplificação</span>}
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showSimplifiedData}
+                onChange={createChangeHandler(setShowSimplifiedData)}
               />
-              <FormControlLabel
-                value="Com Simplificação"
-                control={<Radio />}
-                label={<span style={{ fontSize: '0.8rem' }}>Com Simplificação</span>}
+            }
+            label={showSimplifiedData ? 'Com Simplificação' : 'Sem Simplificação'}
+          />
+          <FormControlLabel
+            control={
+              <Switch
+                checked={showLimitVisibility}
+                onChange={createChangeHandler(setShowLimitVisibility)}
               />
-            </RadioGroup>
-          </FormControl>
+            }
+            label={showLimitVisibility ? 'Sem Limites' : 'Com Limites'}
+          />
         </Grid>
       </Grid>
     </Modal>

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -29,11 +29,10 @@ export default function Principal() {
 
   const [city, setCity] = useState(5003207);
   const [source, setSource] = useState<string | undefined>();
-
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
   const [showFire, setShowFire] = useState(true);
-  const [showLimitVisibility, setLimitVisibility] = useState(false);
+  const [showLimitVisibility, setShowLimitVisibility] = useState(false);
   const [showSatellite, setSatelliteView] = useState(false);
   const [showLocation, setShowLocation] = useState(false);
   const [simplified, setSimplified] = useState(false);
@@ -77,7 +76,7 @@ export default function Principal() {
         sx={{
           position: 'absolute',
           width: '50px',
-          height: '115px',
+          height: '100px',
           top: 0,
           right: 0,
           margin: '1rem',
@@ -86,7 +85,7 @@ export default function Principal() {
           justifyContent: 'space-between',
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '102.5px',
+            height: '110x',
           },
           '@media (max-width: 600px)': {
             top: 'calc(3rem + 40px)',
@@ -106,7 +105,7 @@ export default function Principal() {
         sx={{
           position: 'absolute',
           width: '50px',
-          height: '240px',
+          height: '220px',
           top: '50%',
           right: 0,
           margin: '1rem',
@@ -117,7 +116,7 @@ export default function Principal() {
 
           '@media (max-width: 1500px)': {
             width: '45px',
-            height: '330px',
+            height: '220px',
           },
 
           '@media (max-width: 600px)': {
@@ -126,16 +125,6 @@ export default function Principal() {
           },
         }}
       >
-        <SatelliteButton
-          active={showSatellite}
-          onClick={() => setSatelliteView(!showSatellite)}
-        />
-        
-        <LimitVisibilityButton
-          active={showLimitVisibility}
-          onClick={() => setLimitVisibility(!showLimitVisibility)}
-        />
-
         <FireButton active={showFire} onClick={() => setShowFire(!showFire)} />
 
         <ForestButton active={false} disabled />
@@ -147,7 +136,7 @@ export default function Principal() {
       <Grid
         sx={{
           position: 'absolute',
-          width: '240px',
+          width: '340px',
           height: '50px',
           bottom: 0,
           right: 0,
@@ -157,10 +146,12 @@ export default function Principal() {
           justifyContent: 'space-between',
           '@media (max-width: 1500px)': {
             height: '45px',
-            width: '215px',
+            width: '280px',
           },
         }}
       >
+        <SatelliteButton active={showSatellite} onClick={() => setSatelliteView(!showSatellite)} />
+
         <AddButton onClick={() => ref.current?.zoomIn()} />
 
         <RemoveButton onClick={() => ref.current?.zoomOut()} />
@@ -187,13 +178,16 @@ export default function Principal() {
       <MenuModal
         isDrawerOpen={isDrawerOpen}
         setIsDrawerOpen={setIsDrawerOpen}
-        setIsSettingsVisible={setShowSettings}
+        setShowSettings={setShowSettings}
       />
 
       <Settings
-        isSettingsVisible={showSettings}
-        setIsSettingsVisible={setShowSettings}
-        setIsSimplifiedDatas={setSimplified}
+        showSettings={showSettings}
+        setShowSettings={setShowSettings}
+        showSimplifiedData={simplified}
+        setShowSimplifiedData={setSimplified}
+        showLimitVisibility={showLimitVisibility}
+        setShowLimitVisibility={setShowLimitVisibility}
       />
     </>
   );

--- a/pages/webgis.tsx
+++ b/pages/webgis.tsx
@@ -17,7 +17,6 @@ import {
   CropButton,
   MapButton,
   SettingsButton,
-  LimitVisibilityButton,
   SatelliteButton,
 } from '../components/WebGIS/Buttons';
 import dynamic from 'next/dynamic';


### PR DESCRIPTION
Após a discussão de alguns pontos de melhorias na reunião do dia 03/05/2024, foi realizado a melhoria na disposição de alguns botões relacionados à algumas funcionalidades recentemente implementadas.
Foi decidido que a parte lateral direita do site, ficaria responsável apenas por botões relacionados a visualização de pontos no mapa(queimadas,alagamentos, etc.), portanto, a funcionalidade de visualizar limites de municípios passou para dentro do menu de configurações, esse também que foi mudado para uma lógica de switchs ao invés de radioButton, e o botão que alterna as camadas do mapa, provisoriamente, foi mudado para a parte inferior do mapa, junto com os botões de navegabilidade.
Essa PR resolve os problemas das issues #49 e #50 


Para questões de histórico, essa é uma segunda PR, a primeira foi feito um MERGE indevido para a branch main e foi convertido. Dessa vez a PR tem como alvo a branch development como deveria ser.

