### PR TITLE
feat: adicionando url dinâmica para página de estatísticas

### DIFF
--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -1,28 +1,38 @@
 import React, { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import {
-  Grid,
-  Card,
-  CardContent,
-  Typography,
-  Box,
-  Button,
-} from '@mui/material';
+import { Grid, Card, CardContent, Typography, Box, Button } from '@mui/material';
+import { useRouter } from 'next/router';
 import Menu from '../components/MainMenu';
 import FilterBar from '../components/Estatisticas/FilterBar';
 import EstatisticasTable from '../components/Estatisticas/EstatisticasTable';
 import EstatisticasBarChart from '../components/Estatisticas/EstatisticasBarChart'; 
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 
 const EstatisticasLineChart = dynamic(() => import('../components/Estatisticas/EstatisticasLineChart'), {
   ssr: false,
 });
 
+function isValidParam(param: any): boolean {
+  return typeof param === 'string' && param.length > 0;
+}
 
-export default function Estatisticas() {
-  const [estadoId, setEstadoId] = useState<string | null>(null);
-  const [municipioId, setMunicipioId] = useState<string | null>(null);
-  const [biomaId, setBiomaId] = useState<string | null>(null);
+export const getServerSideProps = (async ({ query }) => {
+  const props: { estadoId?: string; municipioId?: string; biomaId?: string } = {};
+
+  if (isValidParam(query.estadoId)) props.estadoId = query.estadoId as string;
+  if (isValidParam(query.municipioId)) props.municipioId = query.municipioId as string;
+  if (isValidParam(query.biomaId)) props.biomaId = query.biomaId as string;
+
+  return { props };
+}) satisfies GetServerSideProps<{ estadoId?: string; municipioId?: string; biomaId?: string }>;
+
+export default function Estatisticas(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
+  const [estadoId, setEstadoId] = useState<string | null>(props.estadoId || null);
+  const [municipioId, setMunicipioId] = useState<string | null>(props.municipioId || null);
+  const [biomaId, setBiomaId] = useState<string | null>(props.biomaId || null);
   const [isClient, setIsClient] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
 
@@ -30,17 +40,47 @@ export default function Estatisticas() {
     setIsClient(true);
   }, []);
 
+  useEffect(() => {
+    const { estadoId, municipioId, biomaId } = router.query;
+    if (isValidParam(estadoId)) setEstadoId(estadoId as string);
+    if (isValidParam(municipioId)) setMunicipioId(municipioId as string);
+    if (isValidParam(biomaId)) setBiomaId(biomaId as string);
+  }, [router.query]);
+
   const handleEstadoChange = (id: string) => {
     setEstadoId(id);
-    setMunicipioId(null);  
+    setMunicipioId(null);
+    router.push({
+      query: {
+        ...router.query, 
+        estadoId: id,
+        municipioId: undefined,  
+      }
+    });
   };
 
   const handleMunicipioChange = (id: string) => {
     setMunicipioId(id);
+    router.push({
+      query: {
+        ...router.query,  
+        municipioId: id
+      }
+    });
   };
 
   const handleBiomaChange = (id: string) => {
     setBiomaId(id);
+    setEstadoId(null);
+    setMunicipioId(null);
+    router.push({
+      query: {
+        ...router.query,
+        biomaId: id,
+        estadoId: undefined, 
+        municipioId: undefined 
+      }
+    });
   };
 
   const toggleFilter = () => {
@@ -51,15 +91,13 @@ export default function Estatisticas() {
     <>
       <Head>
         <title>WegGis - Estatísticas</title>
-        <style>
-          {`
-            html, body {
-              height: 100%;
-              margin: 0;
-              background-color: #0F1C3C !important;
-            }
-          `}
-        </style>
+        <style>{`
+          html, body {
+            height: 100%;
+            margin: 0;
+            background-color: #0F1C3C !important;
+          }
+        `}</style>
       </Head>
       <Menu />
 
@@ -71,13 +109,7 @@ export default function Estatisticas() {
         />
       )}
 
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'left',
-          marginTop: '1rem',
-        }}
-      >
+      <Box sx={{ display: 'flex', justifyContent: 'left', marginTop: '1rem' }}>
         <Button
           variant="contained"
           color="primary"
@@ -89,43 +121,33 @@ export default function Estatisticas() {
             color: 'white',
             padding: 2,
             marginLeft: 2,
-            '&:hover': {
-              backgroundColor: '#0F1C3C',
-            },
+            '&:hover': { backgroundColor: '#0F1C3C' },
           }}
         >
           {showFilter ? 'Esconder Filtros' : 'Mostrar Filtros'}
         </Button>
       </Box>
 
-      <Grid
-        container
-        spacing={2}
-        sx={{
-          backgroundColor: '#0F1C3C',
-          padding: 2,
-          marginTop: '2rem',
-        }}
-      >
+      <Grid container spacing={2} sx={{ backgroundColor: '#0F1C3C', padding: 2, marginTop: '2rem' }}>
         {/* Primeira Camada: Gráfico de Barras + Tabelas */}
         {isClient && (
           <>
             <Grid item xs={12} lg={6}>
               <EstatisticasBarChart 
-                  title="Linha do tempo de focos de queimadas" 
-                  estadoId={estadoId || undefined}
-                  municipioId={municipioId || undefined}
-                  biomaId={biomaId || undefined} />
+                title="Linha do tempo de focos de queimadas" 
+                estadoId={estadoId || undefined}
+                municipioId={municipioId || undefined}
+                biomaId={biomaId || undefined} 
+              />
             </Grid>
-
             <Grid item xs={12} lg={6}>
               <Grid container spacing={2} sx={{ height: '100%' }}>
                 <Grid item xs={12} sm={12}>
                   <EstatisticasTable 
-                  title="Ranking de meses" 
-                  estadoId={estadoId || undefined}
-                  municipioId={municipioId || undefined}
-                  biomaId={biomaId || undefined}
+                    title="Ranking de meses" 
+                    estadoId={estadoId || undefined}
+                    municipioId={municipioId || undefined}
+                    biomaId={biomaId || undefined} 
                   />
                 </Grid>
               </Grid>
@@ -136,30 +158,16 @@ export default function Estatisticas() {
         {/* Segunda Camada: Gráfico de Linhas */}
         {isClient && (
           <Grid item xs={12} sx={{ marginTop: 2 }}>
-            <Card
-              sx={{
-                backgroundColor: '#509CBF',
-                borderRadius: '25px',
-              }}
-            >
+            <Card sx={{ backgroundColor: '#509CBF', borderRadius: '25px' }}>
               <CardContent sx={{ padding: 3 }}>
-                <Typography
-                  variant="h6"
-                  sx={{ color: 'white', marginBottom: 2, textAlign: 'center' }}
-                >
+                <Typography variant="h6" sx={{ color: 'white', marginBottom: 2, textAlign: 'center' }}>
                   Linha do tempo de área queimada
                 </Typography>
-                <Box
-                  sx={{
-                    backgroundColor: 'white',
-                    borderRadius: '15px',
-                    padding: '15px',
-                  }}
-                >
+                <Box sx={{ backgroundColor: 'white', borderRadius: '15px', padding: '15px' }}>
                   <EstatisticasLineChart 
                     estadoId={estadoId || undefined} 
                     municipioId={municipioId || undefined} 
-                    biomaId={biomaId || undefined}
+                    biomaId={biomaId || undefined} 
                   />
                 </Box>
               </CardContent>


### PR DESCRIPTION
Esse PR adiciona url dinâmica para página de estatísticas de maneira semelhante à lógica já existente na página webgis. O usuário que acessar determinada url sobre um bioma, estado ou município específico poderá carregar automaticamente tais dados desejados.