### PR TITLE
96 refatorar codigo de estatistica

### DIFF
--- a/components/Estatisticas/EstatisticasBarChart.tsx
+++ b/components/Estatisticas/EstatisticasBarChart.tsx
@@ -1,35 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
 import { Box, Card, CardContent, Typography } from '@mui/material';
-import { fetchEstatisticasBioma, fetchEstatisticasEstado, fetchEstatisticasMunicipio } from '../../hooks/useEstatisticas';
+import { fetchEstatisticas } from '../../hooks/useEstatisticas';
 
 interface EstatisticasBarChartProps {
-    estadoId?: string;
-    municipioId?: string;
-    biomaId?: string;
+    local?: string;
+    localId?: string;
     title: string;
 }
 
-const EstatisticasBarChart: React.FC<EstatisticasBarChartProps> = ({ estadoId, municipioId, biomaId, title }) => {
+const EstatisticasBarChart: React.FC<EstatisticasBarChartProps> = ({ local, localId, title }) => {
     const [data, setData] = useState<Array<any>>([]);
 
     useEffect(() => {
         const getEstatisticas = async () => {
           try {
             let response: any[] = [];
-    
-            if (municipioId) {
-              console.log('Buscando estatísticas do município...');
-              const municipioData = await fetchEstatisticasMunicipio(municipioId);
-              response = municipioData;
-            } else if (estadoId) {
-              console.log('Buscando estatísticas do estado...');
-              const estadoData = await fetchEstatisticasEstado(estadoId);
-              response = estadoData;
-            } else if (biomaId) {
-              console.log('Buscando estatísticas do bioma...');
-              const biomaData = await fetchEstatisticasBioma(biomaId);
-              response = biomaData;
+            
+            if(local && localId){
+              console.log(`Buscando estatísticas do ${local}...`);
+              const data = await fetchEstatisticas(local, localId)
+              response = data;
             }
     
             if (response.length === 0) {
@@ -54,7 +45,7 @@ const EstatisticasBarChart: React.FC<EstatisticasBarChartProps> = ({ estadoId, m
         }
 
         getEstatisticas();
-    }, [estadoId, municipioId, biomaId]); 
+    }, [localId]); 
 
   return (
     <Card

--- a/components/Estatisticas/EstatisticasBarChart.tsx
+++ b/components/Estatisticas/EstatisticasBarChart.tsx
@@ -45,7 +45,7 @@ const EstatisticasBarChart: React.FC<EstatisticasBarChartProps> = ({ local, loca
         }
 
         getEstatisticas();
-    }, [localId]); 
+    }, [local, localId]); 
 
   return (
     <Card

--- a/components/Estatisticas/EstatisticasLineChart.tsx
+++ b/components/Estatisticas/EstatisticasLineChart.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { Typography } from '@mui/material';
-import { fetchEstatisticasEstado, fetchEstatisticasMunicipio, fetchEstatisticasBioma } from '../../hooks/useEstatisticas';
+import { fetchEstatisticas } from '../../hooks/useEstatisticas';
 
 interface EstatisticasLineChartProps {
-  estadoId?: string;
-  municipioId?: string;
-  biomaId?: string;
+  local?: string;
+  localId?: string;
 }
 
-const EstatisticasLineChart: React.FC<EstatisticasLineChartProps> = ({ estadoId, municipioId, biomaId }) => {
+const EstatisticasLineChart: React.FC<EstatisticasLineChartProps> = ({ local, localId }) => {
   const [data, setData] = useState<Array<any>>([]);
 
   useEffect(() => {
@@ -17,18 +16,10 @@ const EstatisticasLineChart: React.FC<EstatisticasLineChartProps> = ({ estadoId,
       try {
         let response: any[] = [];
 
-        if (municipioId) {
-          console.log('Buscando estatísticas do município...');
-          const municipioData = await fetchEstatisticasMunicipio(municipioId);
-          response = municipioData;
-        } else if (estadoId) {
-          console.log('Buscando estatísticas do estado...');
-          const estadoData = await fetchEstatisticasEstado(estadoId);
-          response = estadoData;
-        } else if (biomaId) {
-          console.log('Buscando estatísticas do bioma...');
-          const biomaData = await fetchEstatisticasBioma(biomaId);
-          response = biomaData;
+        if(local && localId){
+          console.log(`Buscando estatísticas do ${local}...`);
+          const data = await fetchEstatisticas(local, localId)
+          response = data;
         }
 
         if (response.length === 0) {
@@ -52,7 +43,7 @@ const EstatisticasLineChart: React.FC<EstatisticasLineChartProps> = ({ estadoId,
     };
 
     getEstatisticas();
-  }, [estadoId, municipioId, biomaId]); 
+  }, [localId]); 
 
   return (
     <>

--- a/components/Estatisticas/EstatisticasLineChart.tsx
+++ b/components/Estatisticas/EstatisticasLineChart.tsx
@@ -43,7 +43,7 @@ const EstatisticasLineChart: React.FC<EstatisticasLineChartProps> = ({ local, lo
     };
 
     getEstatisticas();
-  }, [localId]); 
+  }, [local, localId]); 
 
   return (
     <>

--- a/components/Estatisticas/EstatisticasTable.tsx
+++ b/components/Estatisticas/EstatisticasTable.tsx
@@ -45,7 +45,7 @@ const EstatisticasTable: React.FC<EstatisticasTableProps> = ({ local, localId, t
     };
 
     getEstatisticas();
-  }, [localId]);
+  }, [local, localId]);
 
   return (
     <Card

--- a/components/Estatisticas/EstatisticasTable.tsx
+++ b/components/Estatisticas/EstatisticasTable.tsx
@@ -1,15 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { Card, CardContent, Typography, Box, Table, TableHead, TableRow, TableCell, TableBody } from '@mui/material';
-import { fetchEstatisticasEstado, fetchEstatisticasMunicipio, fetchEstatisticasBioma } from '../../hooks/useEstatisticas';
+import { fetchEstatisticas } from '../../hooks/useEstatisticas';
 
 interface EstatisticasTableProps {
+  local?: string;
+  localId?: string;
   title: string;
-  estadoId?: string;
-  municipioId?: string;
-  biomaId?: string;
 }
 
-const EstatisticasTable: React.FC<EstatisticasTableProps> = ({ title, estadoId, municipioId, biomaId }) => {
+const EstatisticasTable: React.FC<EstatisticasTableProps> = ({ local, localId, title }) => {
   const [data, setData] = useState<any[]>([]);
 
   useEffect(() => {
@@ -17,18 +16,10 @@ const EstatisticasTable: React.FC<EstatisticasTableProps> = ({ title, estadoId, 
       try {
         let response: any[] = [];
 
-        if (municipioId) {
-          console.log('Buscando estatísticas do município...');
-          const municipioData = await fetchEstatisticasMunicipio(municipioId);
-          response = municipioData;
-        } else if (estadoId) {
-          console.log('Buscando estatísticas do estado...');
-          const estadoData = await fetchEstatisticasEstado(estadoId);
-          response = estadoData;
-        } else if (biomaId) {
-          console.log('Buscando estatísticas do bioma...');
-          const biomaData = await fetchEstatisticasBioma(biomaId);
-          response = biomaData;
+        if(local && localId){
+          console.log(`Buscando estatísticas do ${local}...`);
+          const data = await fetchEstatisticas(local, localId)
+          response = data;
         }
 
         if (response.length === 0) {
@@ -54,7 +45,7 @@ const EstatisticasTable: React.FC<EstatisticasTableProps> = ({ title, estadoId, 
     };
 
     getEstatisticas();
-  }, [estadoId, municipioId, biomaId]);
+  }, [localId]);
 
   return (
     <Card

--- a/components/Estatisticas/FilterBar.tsx
+++ b/components/Estatisticas/FilterBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { MenuItem, Select, FormControl, InputLabel, SelectChangeEvent, Box, Typography, useStepContext } from '@mui/material';
+import { MenuItem, Select, FormControl, InputLabel, SelectChangeEvent, Box, Typography } from '@mui/material';
 import { styled } from '@mui/system';
 import { fetchComEstatisticas } from '../../hooks/useEstatisticas';
   
@@ -140,7 +140,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onLocalChange }) => {
     if (estadoSelecionado && municipios.length > 0) {
       filterMunicipiosByEstado(estadoSelecionado);
     }
-  }, [municipios, estadoSelecionado]);
+  }, [municipios, estadoSelecionado, filterMunicipiosByEstado]);
 
   return (
     <FiltrosContainer>

--- a/components/Estatisticas/FilterBar.tsx
+++ b/components/Estatisticas/FilterBar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { MenuItem, Select, FormControl, InputLabel, SelectChangeEvent, Box, Typography } from '@mui/material';
+import { MenuItem, Select, FormControl, InputLabel, SelectChangeEvent, Box, Typography, useStepContext } from '@mui/material';
 import { styled } from '@mui/system';
-import { fetchEstadosComEstatisticas, fetchMunicipiosComEstatisticas, fetchBiomasComEstatisticas } from '../../hooks/useEstatisticas';
+import { fetchComEstatisticas } from '../../hooks/useEstatisticas';
   
 const FiltrosContainer = styled(Box)(({ theme }) => ({
   backgroundColor: '#0A2846', 
@@ -34,21 +34,22 @@ const FormControlCustom = styled(FormControl)(({ theme }) => ({
 }));
 
 interface FilterBarProps {
-  onEstadoChange: (estadoId: string, estadoNome: string) => void;
-  onMunicipioChange: (municipioId: string, municipioNome: string) => void;
-  onBiomaChange: (biomaId: string, biomaNome: string) => void;
+  onLocalChange: (local: string, localId: string, localNome: string) => void;
 }
 
-const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange, onBiomaChange }) => {
-  const [filtroSelecionado, setFiltroSelecionado] = useState<string>('');
+const FilterBar: React.FC<FilterBarProps> = ({ onLocalChange }) => {
+  const [biomas, setBiomas] = useState<{ id: string; nome: string }[]>([]);
   const [estados, setEstados] = useState<{ id: string; nome: string; sigla: string }[]>([]);
   const [municipios, setMunicipios] = useState<{ id: string; nome: string; sigla: string }[]>([]);
+
+  const [biomaSelecionado, setBiomaSelecionado] = useState<string>('');
   const [estadoSelecionado, setEstadoSelecionado] = useState<string>('');
   const [municipioSelecionado, setMunicipioSelecionado] = useState<string>('');
+
+  const [filtroSelecionado, setFiltroSelecionado] = useState<string>('');
+
   const [municipiosFiltrados, setMunicipiosFiltrados] = useState<{ id: string; nome: string; sigla: string }[]>([]);
   const [carregandoMunicipios, setCarregandoMunicipios] = useState<boolean>(false);
-  const [biomas, setBiomas] = useState<{ id: string; nome: string }[]>([]);
-  const [biomaSelecionado, setBiomaSelecionado] = useState<string>('');
 
   const handleFiltroChange = (event: SelectChangeEvent<string>) => {
     const filtro = event.target.value as string;
@@ -60,18 +61,28 @@ const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange
       setMunicipioSelecionado('');
       setMunicipiosFiltrados([]);
       fetchEstados();
+
     } else if (filtro === 'Biomas') {
       setEstadoSelecionado('');
       setMunicipioSelecionado('');
       setMunicipiosFiltrados([]);
       setBiomaSelecionado(''); 
-      fetchBiomas();
+      fetchBiomas(); 
+    }
+  };
+
+  const fetchBiomas = async () => {
+    try {
+      const data = await fetchComEstatisticas("biomas");
+      setBiomas(data);
+    } catch (error) {
+      console.error('Erro ao buscar estados:', error);
     }
   };
 
   const fetchEstados = async () => {
     try {
-      const data = await fetchEstadosComEstatisticas();
+      const data = await fetchComEstatisticas("estados");
       setEstados(data);
     } catch (error) {
       console.error('Erro ao buscar estados:', error);
@@ -81,7 +92,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange
   const fetchMunicipios = async () => {
     setCarregandoMunicipios(true);
     try {
-      const data = await fetchMunicipiosComEstatisticas();
+      const data = await fetchComEstatisticas("municipios");
       setMunicipios(data);
       filterMunicipiosByEstado(estadoSelecionado);
     } catch (error) {
@@ -91,24 +102,23 @@ const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange
     }
   };
 
-  const fetchBiomas = async () => {
-    try {
-      const data = await fetchBiomasComEstatisticas();
-      setBiomas(data);
-    } catch (error) {
-      console.error('Erro ao buscar biomas:', error);
+  const handleBiomaChange = (event: SelectChangeEvent<string>) => {
+    const biomaId = event.target.value;
+    const bioma = biomas.find(b => b.id === biomaId);
+    if (bioma) {
+      setBiomaSelecionado(biomaId);
+      onLocalChange('biomas', biomaId, bioma.nome);
     }
   };
 
   const handleEstadoChange = (event: SelectChangeEvent<string>) => {
     const sigla = event.target.value;
     setEstadoSelecionado(sigla);
-    setMunicipioSelecionado(''); 
 
     const estado = estados.find((estado) => estado.sigla === sigla);
     if (estado) {
-      onEstadoChange(estado.id, estado.nome);
-      fetchMunicipios(); 
+      onLocalChange('estados', estado.id, estado.nome);
+      fetchMunicipios();
     }
   };
 
@@ -117,16 +127,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange
     const municipio = municipios.find(m => m.id === municipioId);
     if (municipio) {
       setMunicipioSelecionado(municipioId);
-      onMunicipioChange(municipioId, municipio.nome);
-    }
-  };
-
-  const handleBiomaChange = (event: SelectChangeEvent<string>) => {
-    const biomaId = event.target.value;
-    const bioma = biomas.find(b => b.id === biomaId);
-    if (bioma) {
-      setBiomaSelecionado(biomaId);
-      onBiomaChange(biomaId, bioma.nome);
+      onLocalChange('municipios', municipioId, municipio.nome);
     }
   };
 
@@ -139,7 +140,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onEstadoChange, onMunicipioChange
     if (estadoSelecionado && municipios.length > 0) {
       filterMunicipiosByEstado(estadoSelecionado);
     }
-  }, [municipios, estadoSelecionado, filterMunicipiosByEstado]);
+  }, [municipios, estadoSelecionado]);
 
   return (
     <FiltrosContainer>

--- a/hooks/useEstatisticas.ts
+++ b/hooks/useEstatisticas.ts
@@ -1,36 +1,12 @@
 import axios from 'axios';
 
-export const fetchMunicipiosComEstatisticas = async () => {
-  const response = await axios.get('/api/estatisticas/municipios');
+export const fetchComEstatisticas = async (local: string) => {
+  const response = await axios.get(`/api/estatisticas/${local}`);
   return response.data;
 };
 
-export const fetchEstadosComEstatisticas = async () => {
-  const response = await axios.get('/api/estatisticas/estados');
-  return response.data;
-};
-
-export const fetchEstatisticasMunicipio = async (municipioId: string, ano?: string) => {
-  const response = await axios.get(`/api/estatisticas/municipios/${municipioId}`, {
-    params: { year: ano },
-  });
-  return response.data;
-};
-
-export const fetchEstatisticasEstado = async (estadoId: string, ano?: string) => {
-  const response = await axios.get(`/api/estatisticas/estados/${estadoId}`, {
-    params: { year: ano },
-  });
-  return response.data;
-};
-
-export const fetchBiomasComEstatisticas = async () => {
-  const response = await axios.get('/api/estatisticas/biomas');
-  return response.data;
-};
-
-export const fetchEstatisticasBioma = async (biomaId: string, ano?: string) => {
-  const response = await axios.get(`/api/estatisticas/biomas/${biomaId}`, {
+export const fetchEstatisticas = async (local: string, localId: string, ano?: string) => {
+  const response = await axios.get(`/api/estatisticas/${local}/${localId}`, {
     params: { year: ano },
   });
   return response.data;

--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -43,9 +43,18 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
 
   useEffect(() => {
     const { estadoId, municipioId, biomaId } = router.query;
-    if (isValidParam(estadoId)) setLocalId(estadoId as string);
-    if (isValidParam(municipioId)) setLocalId(municipioId as string);
-    if (isValidParam(biomaId)) setLocalId(biomaId as string);
+    if (isValidParam(estadoId)){
+      setLocalId(estadoId as string);
+      setLocal('estados');
+    };
+    if (isValidParam(municipioId)){
+      setLocalId(municipioId as string);
+      setLocal('municipios');
+    }
+    if (isValidParam(biomaId)){
+      setLocalId(biomaId as string);
+      setLocal('biomas');
+    };
   }, [router.query]);
 
   const handleLocalChange = (local: string, localId: string, localNome: string) =>{

--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -18,7 +18,7 @@ function isValidParam(param: any): boolean {
 }
 
 export const getServerSideProps = (async ({ query }) => {
-  const props: { estadoId?: string; municipioId?: string; biomaId?: string } = {municipioId: "5003207"};
+  const props: { estadoId?: string; municipioId?: string; biomaId?: string } = {};
 
   if (isValidParam(query.estadoId)) props.estadoId = query.estadoId as string;
   if (isValidParam(query.municipioId)) props.municipioId = query.municipioId as string;
@@ -30,13 +30,11 @@ export const getServerSideProps = (async ({ query }) => {
 export default function Estatisticas(props: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 
-  const [estadoId, setEstadoId] = useState<string | null>(props.estadoId || null);
-  const [municipioId, setMunicipioId] = useState<string | null>(props.municipioId || null);
-  const [biomaId, setBiomaId] = useState<string | null>(props.biomaId || null);
-
   const [isClient, setIsClient] = useState(false);
   const [showFilter, setShowFilter] = useState(false);
 
+  const [local, setLocal] = useState<string | null>('');
+  const [localId, setLocalId] = useState<string | null>(null);
   const [localSelecionado, setLocalSelecionado] = useState<string | null>(null);
 
   useEffect(() => {
@@ -44,57 +42,47 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
   }, []);
 
   useEffect(() => {
-    if (municipioId === "5003207") {
-      setLocalSelecionado("Corumbá");
-    }
-  }, [municipioId]);
-  
-
-  useEffect(() => {
     const { estadoId, municipioId, biomaId } = router.query;
-    if (isValidParam(estadoId)) setEstadoId(estadoId as string);
-    if (isValidParam(municipioId)) setMunicipioId(municipioId as string);
-    if (isValidParam(biomaId)) setBiomaId(biomaId as string);
+    if (isValidParam(estadoId)) setLocalId(estadoId as string);
+    if (isValidParam(municipioId)) setLocalId(municipioId as string);
+    if (isValidParam(biomaId)) setLocalId(biomaId as string);
   }, [router.query]);
 
-  const handleEstadoChange = (id: string, nome: string) => {
-    setEstadoId(id);
-    setMunicipioId(null);
-    setLocalSelecionado(nome);
-    router.push({
-      query: {
-        ...router.query, 
-        estadoId: id,
-        municipioId: undefined,  
-      }
-    });
-  };
-  
-  const handleMunicipioChange = (id: string, nome: string) => {
-    setMunicipioId(id);
-    setLocalSelecionado(nome);
-    router.push({
-      query: {
-        ...router.query,  
-        municipioId: id
-      }
-    });
-  };
-  
-  const handleBiomaChange = (id: string, nome: string) => {
-    setBiomaId(id);
-    setEstadoId(null);
-    setMunicipioId(null);
-    setLocalSelecionado(nome);
-    router.push({
-      query: {
-        ...router.query,
-        biomaId: id,
-        estadoId: undefined, 
-        municipioId: undefined 
-      }
-    });
-  };
+  const handleLocalChange = (local: string, localId: string, localNome: string) =>{
+    setLocal(local)
+    setLocalId(localId);
+    setLocalSelecionado(localNome);
+
+    if (local === 'municipios'){
+      router.push({
+        query: {
+          ...router.query,
+          biomaId: undefined,
+          municipioId: localId
+        }
+      });
+    }
+
+    else if (local === 'biomas'){
+      router.push({
+        query: {
+          ...router.query,
+          biomaId: localId,
+          estadoId: undefined,
+          municipioId: undefined
+        }
+      });
+    } else if (local === 'estados'){
+      router.push({
+        query: {
+          ...router.query,
+          biomaId: undefined,
+          estadoId: localId,
+          municipioId: undefined
+        }
+      });
+    }
+  }
 
   const toggleFilter = () => {
     setShowFilter(!showFilter);
@@ -116,9 +104,7 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
 
       {isClient && showFilter && (
         <FilterBar 
-          onEstadoChange={handleEstadoChange}
-          onMunicipioChange={handleMunicipioChange}
-          onBiomaChange={handleBiomaChange}
+          onLocalChange={handleLocalChange}
         />
       )}
 
@@ -151,10 +137,9 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
           <>
             <Grid item xs={12} lg={6}>
               <EstatisticasBarChart 
-                title="Linha do tempo de focos de queimadas" 
-                estadoId={estadoId || undefined}
-                municipioId={municipioId || undefined}
-                biomaId={biomaId || undefined} 
+                title="Linha do tempo de focos de queimadas"
+                local={local || undefined}
+                localId={localId || undefined}
               />
             </Grid>
             <Grid item xs={12} lg={6}>
@@ -162,9 +147,8 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
                 <Grid item xs={12} sm={12}>
                   <EstatisticasTable 
                     title="Ranking de meses" 
-                    estadoId={estadoId || undefined}
-                    municipioId={municipioId || undefined}
-                    biomaId={biomaId || undefined} 
+                    local={local || undefined}
+                    localId={localId || undefined}
                   />
                 </Grid>
               </Grid>
@@ -182,9 +166,8 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
                 </Typography>
                 <Box sx={{ backgroundColor: 'white', borderRadius: '15px', padding: '15px' }}>
                   <EstatisticasLineChart 
-                    estadoId={estadoId || undefined} 
-                    municipioId={municipioId || undefined} 
-                    biomaId={biomaId || undefined} 
+                    local={local || undefined}
+                    localId={localId || undefined} 
                   />
                 </Box>
               </CardContent>


### PR DESCRIPTION
As modificações foram feitas com o objetivo de facilitar a manipulação dos dados de estatísticas. Antes, existiam funções e variáveis diferentes para cada tipo de local, como biomas, estados e municípios. As alterações foram feitas para possibilitar a manipulação desses dados com o menor número de funções e variáveis.