### PR TITLE
95 sincronizar os filtros com a url

### DIFF
--- a/components/Estatisticas/FilterBar.tsx
+++ b/components/Estatisticas/FilterBar.tsx
@@ -52,31 +52,16 @@ const FilterBar: React.FC<FilterBarProps> = ({ onLocalChange, initialBiomaId, in
   const [carregandoMunicipios, setCarregandoMunicipios] = useState<boolean>(false);
 
   useEffect(() => {
-    if (initialBiomaId) {
-      setFiltroSelecionado('Biomas');
-      setBiomaSelecionado(initialBiomaId);
-    } else if (initialEstadoId) {
-      setFiltroSelecionado('Estados');
-      const estado = estados.find(e => e.id === initialEstadoId);
-      if (estado) {
-        setEstadoSelecionado(estado.sigla);
-        onLocalChange('estados', estado.id, estado.nome);
-      }
-    }
-    if (initialMunicipioId) {
-      const municipio = municipios.find(m => m.id === initialMunicipioId);
-      if (municipio) {
-        setMunicipioSelecionado(municipio.id);
-        onLocalChange('municipios', municipio.id, municipio.nome);
-      }
-    }
-  }, [initialBiomaId, initialEstadoId, initialMunicipioId, estados, municipios, onLocalChange]);
-
-  useEffect(() => {
     if (filtroSelecionado === 'Biomas') {
       fetchBiomas();
+      setEstadoSelecionado('');
+      setMunicipioSelecionado('');
+      setMunicipiosFiltrados([]);
     } else {
       fetchEstados();
+      setBiomaSelecionado('');
+      setMunicipioSelecionado('');
+      setMunicipiosFiltrados([]);
     }
   }, [filtroSelecionado]);
 
@@ -93,6 +78,7 @@ const FilterBar: React.FC<FilterBarProps> = ({ onLocalChange, initialBiomaId, in
     setEstadoSelecionado('');
     setMunicipioSelecionado('');
     setMunicipiosFiltrados([]);
+    onLocalChange('', '', ''); // Limpa a seleção anterior
   };
 
   const fetchBiomas = async () => {

--- a/components/Estatisticas/FilterBar.tsx
+++ b/components/Estatisticas/FilterBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { MenuItem, Select, FormControl, InputLabel, SelectChangeEvent, Box, Typography, CircularProgress } from '@mui/material';
 import { styled } from '@mui/system';
 import { fetchComEstatisticas } from '../../hooks/useEstatisticas';

--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
-import { Grid, Card, CardContent, Typography, Box, Button } from '@mui/material';
+import { Grid, Button, Box, Typography, Card, CardContent } from '@mui/material';
 import { useRouter } from 'next/router';
 import Menu from '../components/MainMenu';
 import FilterBar from '../components/Estatisticas/FilterBar';
@@ -41,28 +41,32 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
     setIsClient(true);
   }, []);
 
+  // Sincroniza os filtros e o título com a URL ao carregar a página
   useEffect(() => {
     const { estadoId, municipioId, biomaId } = router.query;
-    if (isValidParam(estadoId)){
+
+    if (isValidParam(estadoId)) {
       setLocalId(estadoId as string);
       setLocal('estados');
-    };
-    if (isValidParam(municipioId)){
+    }
+
+    if (isValidParam(municipioId)) {
       setLocalId(municipioId as string);
       setLocal('municipios');
     }
-    if (isValidParam(biomaId)){
+
+    if (isValidParam(biomaId)) {
       setLocalId(biomaId as string);
       setLocal('biomas');
-    };
+    }
   }, [router.query]);
 
-  const handleLocalChange = (local: string, localId: string, localNome: string) =>{
-    setLocal(local)
+  const handleLocalChange = (local: string, localId: string, localNome: string) => {
+    setLocal(local);
     setLocalId(localId);
     setLocalSelecionado(localNome);
 
-    if (local === 'municipios'){
+    if (local === 'municipios') {
       router.push({
         query: {
           ...router.query,
@@ -70,9 +74,7 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
           municipioId: localId
         }
       });
-    }
-
-    else if (local === 'biomas'){
+    } else if (local === 'biomas') {
       router.push({
         query: {
           ...router.query,
@@ -81,7 +83,7 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
           municipioId: undefined
         }
       });
-    } else if (local === 'estados'){
+    } else if (local === 'estados') {
       router.push({
         query: {
           ...router.query,
@@ -91,7 +93,7 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
         }
       });
     }
-  }
+  };
 
   const toggleFilter = () => {
     setShowFilter(!showFilter);
@@ -114,6 +116,9 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
       {isClient && showFilter && (
         <FilterBar 
           onLocalChange={handleLocalChange}
+          initialBiomaId={props.biomaId}
+          initialEstadoId={props.estadoId}
+          initialMunicipioId={props.municipioId}
         />
       )}
 
@@ -135,13 +140,13 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
           {showFilter ? 'Esconder Filtros' : 'Mostrar Filtros'}
         </Button>
       </Box>
-      
-      <Typography variant='h2' style={{textAlign:"center", color:"white"}}>
-          {localSelecionado}
+
+      <Typography variant='h2' style={{ textAlign: "center", color: "white" }}>
+        {localSelecionado}
       </Typography>
 
       <Grid container spacing={2} sx={{ backgroundColor: '#0F1C3C', padding: 2, marginTop: '2rem' }}>
-        {/* Primeira Camada: Gráfico de Barras + Tabelas */}
+        {/* Gráfico de Barras + Tabelas */}
         {isClient && (
           <>
             <Grid item xs={12} lg={6}>
@@ -165,7 +170,7 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
           </>
         )}
 
-        {/* Segunda Camada: Gráfico de Linhas */}
+        {/* Gráfico de Linhas */}
         {isClient && (
           <Grid item xs={12} sx={{ marginTop: 2 }}>
             <Card sx={{ backgroundColor: '#509CBF', borderRadius: '25px' }}>

--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -43,49 +43,61 @@ export default function Estatisticas(props: InferGetServerSidePropsType<typeof g
 
   useEffect(() => {
     const { estadoId, municipioId, biomaId } = router.query;
-
-    if (isValidParam(estadoId)) {
-        setLocalId(estadoId as string);
-        setLocal('estados');
-    } else if (isValidParam(municipioId)) {
-        setLocalId(municipioId as string);
-        setLocal('municipios');
+  
+   
+    if (isValidParam(municipioId)) {
+      setLocalId(municipioId as string);
+      setLocal('municipios');
+    } else if (isValidParam(estadoId)) {
+      setLocalId(estadoId as string);
+      setLocal('estados');
     } else if (isValidParam(biomaId)) {
-        setLocalId(biomaId as string);
-        setLocal('biomas');
+      setLocalId(biomaId as string);
+      setLocal('biomas');
+    } else {
+      // Definir município padrão no primeiro acesso
+      setLocalId('5003207');
+      setLocal('municipios');
+      setLocalSelecionado("Corumbá");
     }
-}, [router.query]);
+  }, [router.query]);
+  
 
 
-const buildQuery = (local: string, localId: string) => {
-  const query = { ...router.query };
-
-  switch (local) {
+  const buildQuery = (local: string, localId: string) => {
+    const query = { ...router.query };
+  
+    switch (local) {
       case 'municipios':
-          query.biomaId = undefined; 
-          query.municipioId = localId; 
-          break;
+        query.biomaId = undefined;
+        query.municipioId = localId;
+        break;
       case 'biomas':
-          query.estadoId = undefined; 
-          query.municipioId = undefined;
-          query.biomaId = localId; 
-          break;
+        query.estadoId = undefined;
+        query.municipioId = undefined;
+        query.biomaId = localId;
+        break;
       case 'estados':
-          query.biomaId = undefined; 
-          query.municipioId = undefined;
-          query.estadoId = localId; 
-          break;
-  }
-
-  return query;
-};
+        query.biomaId = undefined;
+        query.municipioId = undefined;
+        query.estadoId = localId;
+        break;
+    }
+  
+    return query;
+  };
+  
 
 const handleLocalChange = (local: string, localId: string, localNome: string) => {
   setLocal(local);
   setLocalId(localId);
   setLocalSelecionado(localNome);
-  router.push({ query: buildQuery(local, localId) });
+
+  const newQuery = buildQuery(local, localId);
+
+  router.push({ query: newQuery });
 };
+
 
 
   const toggleFilter = () => {

--- a/pages/estatisticas.tsx
+++ b/pages/estatisticas.tsx
@@ -62,19 +62,18 @@ const buildQuery = (local: string, localId: string) => {
 
   switch (local) {
       case 'municipios':
-          query.biomaId = undefined; // Limpa o bioma se município for selecionado
-          query.estadoId = undefined; // Limpa o estado se município for selecionado
-          query.municipioId = localId; // Define o município selecionado
+          query.biomaId = undefined; 
+          query.municipioId = localId; 
           break;
       case 'biomas':
-          query.estadoId = undefined; // Limpa o estado se bioma for selecionado
-          query.municipioId = undefined; // Limpa o município se bioma for selecionado
-          query.biomaId = localId; // Define o bioma selecionado
+          query.estadoId = undefined; 
+          query.municipioId = undefined;
+          query.biomaId = localId; 
           break;
       case 'estados':
-          query.biomaId = undefined; // Limpa o bioma se estado for selecionado
-          query.municipioId = undefined; // Limpa o município se estado for selecionado
-          query.estadoId = localId; // Define o estado selecionado
+          query.biomaId = undefined; 
+          query.municipioId = undefined;
+          query.estadoId = localId; 
           break;
   }
 
@@ -85,7 +84,7 @@ const handleLocalChange = (local: string, localId: string, localNome: string) =>
   setLocal(local);
   setLocalId(localId);
   setLocalSelecionado(localNome);
-  router.push({ query: buildQuery(local, localId) }); // Atualiza a URL com os parâmetros corretos
+  router.push({ query: buildQuery(local, localId) });
 };
 
 


### PR DESCRIPTION
Esse PR tras como funcionalidade sincronizar os filtros referentes a uma url específica carregada. Exemplo: ao acessar uma url referente a um município ("Corumbá, por exemplo"), ao carregá-la, os filtros "Estados" "Mato Grosso do Sul" e "Corumbá" serão automaticamente sincronizados, melhorando a experiência do usuário.